### PR TITLE
fixed potential memory leak, deleted unnecessary semicolon

### DIFF
--- a/StarCoderApp/starcoderlib/generate.cpp
+++ b/StarCoderApp/starcoderlib/generate.cpp
@@ -714,6 +714,9 @@ extern const StarcoderModel * load_model(const char * model_path) {
 
     if (!starcoder_model_load(model_path, model->model, model->vocab)) {
         fprintf(stderr, "%s: failed to load model from '%s'\n", __func__, model_path);
+        
+        // free the mem, allocated for 'model' before returning
+        delete model;
         return NULL;
     }
     

--- a/convert-hf-to-ggml.py
+++ b/convert-hf-to-ggml.py
@@ -160,10 +160,10 @@ for name in list_vars.keys():
         print("  Skipping variable: " + name)
         continue
 
-    n_dims = len(data.shape);
+    n_dims = len(data.shape)
 
     # ftype == 0 -> float32, ftype == 1 -> float16
-    ftype = 0;
+    ftype = 0
     if use_f16:
         if (name == "model/wte" or name == "model/lm_head" or name[-2:] == "/g" or name[-2:] == "/w") and n_dims == 2:
             print("  Converting to float16")
@@ -201,7 +201,7 @@ for name in list_vars.keys():
     fout.write(struct.pack("iii", n_dims, len(str), ftype))
     for i in range(n_dims):
         fout.write(struct.pack("i", data.shape[n_dims - 1 - i]))
-    fout.write(str);
+    fout.write(str)
 
     # data
     data.tofile(fout)


### PR DESCRIPTION
**Pull Request Summary:**

This pull request addresses a potential memory leak in the `load_model` function by ensuring that the dynamically allocated memory for 'model' is properly deallocated before returning `NULL` in case of a model loading failure. Additionally, it includes changes to the `convert-hf-to-ggml.py` script to improve its readability and consistency.

**Changes Made:**

- Added memory deallocation for 'model' before returning `NULL` in case of a model loading failure.
- Utilized the `delete` operator to release the dynamically allocated memory.
- Removed a few unnecessary semicolons from the `convert-hf-to-ggml.py` script to enhance code readability and consistency.

**Explanation:**

The `load_model` function previously allocated memory for 'model' using the `new` operator but didn't release it in case the model loading failed, potentially causing a memory leak. To address this issue, I added a `delete model;` statement before returning `NULL` when the loading fails.

In the `convert-hf-to-ggml.py` script, I removed a few semicolons that were not required for proper code execution. This change enhances the code's readability and maintains consistency with Python's coding style.